### PR TITLE
Add html_encode to literal

### DIFF
--- a/include/nitro.hrl
+++ b/include/nitro.hrl
@@ -12,7 +12,7 @@
 -define(CTRL_BASE(Module), ?ELEMENT_BASE(Module,undefined,Module)).
 
 -record(element, {?ELEMENT_BASE(undefined)}).
--record(literal, {?ELEMENT_BASE(element_literal)}).
+-record(literal, {?ELEMENT_BASE(element_literal), html_encode=true }).
 -record(dtl, {?ELEMENT_BASE(element_dtl), file="index", bindings=[], app=web, folder="priv/templates", ext="html", bind_script=true, js_escape=false }).
 -record(list, {?ELEMENT_BASE(element_list), numbered=false }).
 -record(dropdown, {?ELEMENT_BASE(element_dropdown), options, value, multiple=false, disabled=false, name}).

--- a/src/elements/element_literal.erl
+++ b/src/elements/element_literal.erl
@@ -3,4 +3,8 @@
 -include_lib("nitro/include/nitro.hrl").
 -compile(export_all).
 
-render_element(Record) -> nitro:html_encode(Record#literal.body).
+render_element(Record = #literal{}) ->
+	case Record#literal.html_encode of
+		true -> nitro:html_encode(Record#literal.body);
+		_    -> Record#literal.body
+	end.


### PR DESCRIPTION
Any change this will be included in master? It allows to also have the raw body included, instead of always html_encoding. I use this to include a proper doctype:

[ #literal { body = "<!doctype html>" }, #html { .... } ]
