### PR TITLE
special render case for nested #jq to avoid generated js format error

### DIFF
--- a/src/actions/action_jq.erl
+++ b/src/actions/action_jq.erl
@@ -19,6 +19,10 @@ render_action(#jq{target=T,method=undefined,property=P,args=simple,right=R,forma
 render_action(#jq{target=T,method=undefined,property=P,right=undefined}) ->
     nitro:f("qi('~s').~s;", [nitro:to_list(T),nitro:to_list(P)]);
 
+render_action(#jq{target=T,method=undefined,property=P,right=#jq{}=R,format=_F}) ->
+    nitro:f("qi('~s').~s = ~s;",
+        [nitro:to_list(T),nitro:to_list(P),binary_to_list(iolist_to_binary(nitro:render(R)))]);
+
 render_action(#jq{target=T,method=undefined,property=P,right=R,format=_F}) ->
     nitro:f("qi('~s').~s = '~s';",
         [nitro:to_list(T),nitro:to_list(P),binary_to_list(iolist_to_binary(nitro:render(R)))]).


### PR DESCRIPTION
One special case to handle nested #jq{} (`#jq{right=#jq{}}`), this avoids generating extra single quotes wrapping on the right-hand expression.

Before:

``` erlang
2>wf:render(#jq{target=history,property=scrollTop,right=#jq{target=history,property=scrollHeight}}).
```

``` javascript
qi('history').scrollTop = 'qi('history').scrollHeight;';
```

```
SyntaxError: missing ; before statement
Stack trace:
onio@http://127.0.0.1:8000/n2o/n2o.js:28:11
onbert/<@http://127.0.0.1:8000/n2o/n2o.js:47:46
```

After:

``` erlang
2>wf:render(#jq{target=history,property=scrollTop,right=#jq{target=history,property=scrollHeight}}).
```

``` javascript
qi('history').scrollTop = qi('history').scrollHeight;;
```
