### PR TITLE
fix postback default values

### DIFF
--- a/include/nitro.hrl
+++ b/include/nitro.hrl
@@ -6,7 +6,7 @@
 -define(ELEMENT_BASE(Module), ?ELEMENT_BASE(Module,undefined,undefined)).
 -define(ELEMENT_BASE(Module,Tag,Delegate),
         ancestor=element, id, module=Module, delegate=Delegate, validation=[], validate=[], actions, class=[], style=[], source=[], onmouseover, onkeypress, onchange, onkeyup, onkeydown, onclick,
-        data_fields=[], aria_states=[], body, role, tabindex, show_if=true, html_tag=Tag, title, postback=[], accesskey, contenteditable, contextmenu, dir, draggable, dropzone,
+        data_fields=[], aria_states=[], body, role, tabindex, show_if=true, html_tag=Tag, title, postback, accesskey, contenteditable, contextmenu, dir, draggable, dropzone,
         hidden, lang, spellcheck, translate, onblur, onerror, onfocus, onmessage, onresize).
 -define(ACTION_BASE(Module), ancestor=action, trigger, target, module=Module, actions, source=[]).
 -define(CTRL_BASE(Module), ?ELEMENT_BASE(Module,undefined,Module)).
@@ -193,7 +193,7 @@
 
 -record(api,     {?ACTION_BASE(action_api), name, tag, delegate }).
 -record(event,   {?ACTION_BASE(action_event), type=default, postback, delegate, validation=[]}).
--record(bind,    {?ACTION_BASE(action_bind), type=click, postback=[]}).
+-record(bind,    {?ACTION_BASE(action_bind), type=click, postback}).
 -record(alert,   {?ACTION_BASE(action_alert), text}).
 -record(confirm, {?ACTION_BASE(action_confirm), text, postback, delegate}).
 -record(jq,      {?ACTION_BASE(action_jq), property, method, args=[], right, format="~s"}).


### PR DESCRIPTION
Postback default value is often checked and compared to undefined to render elements.
Setting it to [] cause the generation of wrong actions.
