### PR TITLE
Fire event on Change not on Click with dropdown!

### DIFF
--- a/src/elements/element_dropdown.erl
+++ b/src/elements/element_dropdown.erl
@@ -6,7 +6,7 @@ render_element(Record = #dropdown{}) ->
     ID = case Record#dropdown.id of undefined -> nitro:temp_id(); I->I end,
     case Record#dropdown.postback of
          undefined -> skip;
-         Postback -> nitro:wire(#event { type=click, postback=Postback, target=ID,
+         Postback -> nitro:wire(#event { type=change, postback=Postback, target=ID,
                         source=Record#dropdown.source, delegate=Record#dropdown.delegate } ) end,
 
     Opts = [wf_tags:emit_tag(<<"option">>, [O#option.label], [


### PR DESCRIPTION
When we wire the postback event to click, it will fire with the user's initial click on the dropdown, not when he has selected an item(which is what the dropdown is for).