### PR TITLE
Fix pattern matching for void tags

### DIFF
--- a/src/render/wf_tags.erl
+++ b/src/render/wf_tags.erl
@@ -3,7 +3,7 @@
 -include_lib("nitro/include/nitro.hrl").
 -compile(export_all).
 -define(VOID(Tag),  (Tag == <<"br">>     orelse Tag == <<"hr">>
-              orelse Tag == <<"link">>   orelse Tag == <<"img">> 
+              orelse Tag == <<"link">>   orelse Tag == <<"img">>
               orelse Tag == <<"input">>  orelse Tag == <<"link">>
               orelse Tag == <<"meta">>   orelse Tag == <<"param">>
               orelse Tag == <<"base">>   orelse Tag == <<"area">>
@@ -13,7 +13,7 @@
 emit_tag(TagName, Props) -> [<<"<">>,TagName] ++ write_props(Props) ++ [<<"/>">>].
 emit_tag(TagName, undefined, Props) -> emit_tag(TagName, [], Props);
 emit_tag(TagName, [undefined], Props) -> emit_tag(TagName, [], Props);
-emit_tag(TagName, [], Props) when ?VOID(TagName) -> emit_tag(TagName, Props);
+emit_tag(TagName, <<>>, Props) when ?VOID(TagName) -> emit_tag(TagName, Props);
 emit_tag(TagName, [], Props) -> [<<"<">>,TagName,write_props(Props),<<">">>,<<"</">>,TagName,<<">">>];
 emit_tag(TagName, Content, Props) -> [<<"<">>,TagName,write_props(Props),<<">">>, Content,<<"</">>,TagName,<<">">>].
 write_props(Props) -> lists:map(fun display_property/1, Props).


### PR DESCRIPTION
Fix for void tags such as `#br{}` to correct `<br/>`, previously `<br></br>` which was wrong. 