### PR TITLE
Add "required" attribute to the "input" tag

### DIFF
--- a/include/nitro.hrl
+++ b/include/nitro.hrl
@@ -64,7 +64,7 @@
 -record(textarea,       {?ELEMENT_BASE(element_textarea), autofocus, cols, dirname, disabled, form, maxlength, name, placeholder, readonly, required, rows, wrap, value}).
 
 % HTML Form inputs
--record(input,       {?ELEMENT_BASE(element_input),  autofocus, disabled, form, name, value, type=[], placeholder, multiple, min, max, pattern, accept}).
+-record(input,       {?ELEMENT_BASE(element_input), required, autofocus, disabled, form, name, value, type=[], placeholder, multiple, min, max, pattern, accept}).
 -record(input_button,       {?ELEMENT_BASE(element_input_button),  autofocus, disabled, form, name, value}).
 -record(checkbox,           {?ELEMENT_BASE(element_checkbox),  autofocus, checked=false, disabled, form, name, required, value}).
 -record(color,           {?ELEMENT_BASE(element_color),  autocomplete, autofocus, disabled, form, list, name, value}).

--- a/src/elements/element_input.erl
+++ b/src/elements/element_input.erl
@@ -46,6 +46,7 @@ render_element(Record) ->
       {<<"onkeyup">>, Record#input.onkeyup},
       {<<"onkeydown">>, Record#input.onkeydown},
       {<<"onclick">>, Record#input.onclick},
+      {<<"required">>, if Record#input.required == true -> "required"; true -> undefined end},
       {<<"onchange">>, Record#input.onchange} | Record#input.data_fields
     ],
     wf_tags:emit_tag(<<"input">>, nitro:render(Record#input.body), List).


### PR DESCRIPTION
Adds the [required](https://developer.mozilla.org/ru/docs/Web/HTML/Element/Input#attr-required) attribute to the [input](https://developer.mozilla.org/ru/docs/Web/HTML/Element/Input) tag.