### PR TITLE
Expose event record to Elixir

### DIFF
--- a/lib/NITRO.ex
+++ b/lib/NITRO.ex
@@ -3,7 +3,7 @@ defmodule NITRO do
 
   files = ["calendar.hrl", "nitro.hrl", "comboLookup.hrl", "nitro_pi.hrl", "comboLookupVec.hrl", "comboLookupEdit.hrl",
            "comboLookupText.hrl", "comboLookupModify.hrl", "comboLookupModify_item.hrl", "comboLookupGroup.hrl",
-           "comboLookupGroup_list.hrl", "comboLookupGroup_item.hrl", "koatuuControl.hrl", "n2o.hrl"]
+           "comboLookupGroup_list.hrl", "comboLookupGroup_item.hrl", "koatuuControl.hrl", "n2o.hrl", "event.hrl"]
 
   hrl_files =
     Enum.filter(files, fn f ->


### PR DESCRIPTION
Makes `#event{}` reachable from Elixir as `NITRO.event(...)`.

Use case: wiring postbacks to elements that already exist in static HTML (e.g. login/signup buttons).